### PR TITLE
feat: add localization support and new forbidden response middleware

### DIFF
--- a/Myrtus.Clarity.Core.Application.Abstractions.Localization/Myrtus.Clarity.Core.Application.Abstractions.Localization.csproj
+++ b/Myrtus.Clarity.Core.Application.Abstractions.Localization/Myrtus.Clarity.Core.Application.Abstractions.Localization.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Myrtus.Clarity.Core.Application.Abstractions.Localization/Services/ILocalizationService.cs
+++ b/Myrtus.Clarity.Core.Application.Abstractions.Localization/Services/ILocalizationService.cs
@@ -1,0 +1,7 @@
+﻿namespace Myrtus.Clarity.Core.Application.Abstractions.Localization.Services
+{
+    public interface ILocalizationService
+    {
+        string GetLocalizedString(string key, string language);
+    }
+}

--- a/Myrtus.Clarity.Core.Domain.Abstractions/DomainError.cs
+++ b/Myrtus.Clarity.Core.Domain.Abstractions/DomainError.cs
@@ -8,6 +8,7 @@ namespace Myrtus.Clarity.Core.Domain.Abstractions
 
         public static readonly DomainError NullValue = new("Error.NullValue", 400, "Null value was provided");
 
+
         // Validation errors
         public IEnumerable<ValidationError>? Errors { get; init; }
 

--- a/Myrtus.Clarity.Core.Infrastructure.Localization/Myrtus.Clarity.Core.Infrastructure.Localization.csproj
+++ b/Myrtus.Clarity.Core.Infrastructure.Localization/Myrtus.Clarity.Core.Infrastructure.Localization.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageReference Include="YamlDotNet" Version="12.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Myrtus.Clarity.Core.Application.Abstractions.Localization\Myrtus.Clarity.Core.Application.Abstractions.Localization.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Myrtus.Clarity.Core.Infrastructure.Localization/Services/LocalizationService.cs
+++ b/Myrtus.Clarity.Core.Infrastructure.Localization/Services/LocalizationService.cs
@@ -1,0 +1,102 @@
+﻿using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+using Myrtus.Clarity.Core.Application.Abstractions.Localization.Services;
+using Microsoft.Extensions.Logging;
+using System.Text;
+
+namespace Myrtus.Clarity.Core.Infrastructure.Localization.Services
+{
+    public class LocalizationService : ILocalizationService
+    {
+        private readonly Dictionary<string, Dictionary<string, string>> _localizedMessages;
+        private readonly ILogger<LocalizationService> _logger;
+
+        public LocalizationService(ILogger<LocalizationService> logger)
+        {
+            _logger = logger;
+            _localizedMessages = LoadLocalizedMessages();
+        }
+
+        public string GetLocalizedString(string key, string language)
+        {
+            if (_localizedMessages.TryGetValue(language, out var messages) && messages.TryGetValue(key, out var message))
+            {
+                return message;
+            }
+
+            var baseLanguage = language.Split('-')[0];
+            if (_localizedMessages.TryGetValue(baseLanguage, out var baseMessages) && baseMessages.TryGetValue(key, out var baseMessage))
+            {
+                return baseMessage;
+            }
+
+            if (_localizedMessages.TryGetValue("en-US", out var defaultMessages) && defaultMessages.TryGetValue(key, out var defaultMessage))
+            {
+                return defaultMessage;
+            }
+
+            return key;
+        }
+
+        private Dictionary<string, Dictionary<string, string>> LoadLocalizedMessages()
+        {
+            var deserializer = new DeserializerBuilder()
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .IgnoreUnmatchedProperties()
+                .Build();
+
+            var localizedMessages = new Dictionary<string, Dictionary<string, string>>();
+            var resourceDirectory = Path.Combine(AppContext.BaseDirectory, "Resources");
+
+            if (Directory.Exists(resourceDirectory))
+            {
+                var yamlFiles = Directory.GetFiles(resourceDirectory, "*.yaml");
+
+                foreach (var filePath in yamlFiles)
+                {
+                    try
+                    {
+                        var language = Path.GetFileNameWithoutExtension(filePath);
+                        var yamlContent = File.ReadAllText(filePath, Encoding.UTF8);
+
+                        var messages = deserializer.Deserialize<Dictionary<string, object>>(yamlContent);
+                        localizedMessages[language] = FlattenDictionary(messages);
+
+                        _logger.LogInformation("Successfully loaded {Count} keys for language {Language}", localizedMessages[language].Count, language);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Error deserializing YAML file: {FilePath}", filePath);
+                    }
+                }
+            }
+
+            return localizedMessages;
+        }
+
+        private Dictionary<string, string> FlattenDictionary(Dictionary<string, object> nestedDict, string parentKey = "")
+        {
+            var flatDict = new Dictionary<string, string>();
+
+            foreach (var pair in nestedDict)
+            {
+                var key = string.IsNullOrEmpty(parentKey) ? pair.Key : $"{parentKey}.{pair.Key}";
+
+                if (pair.Value is Dictionary<object, object> nested)
+                {
+                    var nestedDictTyped = nested.ToDictionary(k => k.Key.ToString()!, v => v.Value);
+                    foreach (var innerPair in FlattenDictionary(nestedDictTyped, key))
+                    {
+                        flatDict[innerPair.Key] = innerPair.Value;
+                    }
+                }
+                else
+                {
+                    flatDict[key] = pair.Value?.ToString() ?? string.Empty;
+                }
+            }
+
+            return flatDict;
+        }
+    }
+}

--- a/Myrtus.Clarity.Core.WebApi/Myrtus.Clarity.Core.WebApi.csproj
+++ b/Myrtus.Clarity.Core.WebApi/Myrtus.Clarity.Core.WebApi.csproj
@@ -14,6 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Myrtus.Clarity.Core.Application.Abstractions.Localization\Myrtus.Clarity.Core.Application.Abstractions.Localization.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Update="SonarAnalyzer.CSharp" Version="9.32.0.97167">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Added new projects for localization and updated solution configuration. Introduced `ForbiddenResponseMiddleware` for handling forbidden requests with localized error messages. Commented out `AddLocalization` in `DependencyInjection.cs` and added localization services in `AddWebApi`. Added localization resources `en.yaml` and `tr.yaml`. Updated `Program.cs` and `ExceptionHandlingMiddleware` to use localization services. Added `ILocalizationService` and its implementation. Updated `ErrorHandlingService` and various classes to support localization. Updated `docker-compose.dcproj` and added new methods for better error handling.