### PR TITLE
feat! Add notification read functionality and update queries

### DIFF
--- a/Myrtus.Clarity.Core.Application.Abstractions.Notification/INotificationService.cs
+++ b/Myrtus.Clarity.Core.Application.Abstractions.Notification/INotificationService.cs
@@ -7,5 +7,6 @@
         Task SaveNotificationAsync(string details, string userId);
         Task SendNotificationToUserGroupAsync(string details, string groupName);
         Task<List<Domain.Abstractions.Notification>> GetNotificationsByUserIdAsync(string userId);
+        Task MarkNotificationsAsReadAsync(string UserId, CancellationToken cancellation);
     }
 }


### PR DESCRIPTION
- Added `GetAllNotificationsWithUnreadCountResponse.cs` for paginated notifications and unread count.
- Modified `GetAllAuditLogsQueryHandler.cs` and `GetAllAuditLogsDynamicQueryHandler.cs` to include a `predicate` parameter in `GetAllAsync`.
- Added `MarkNotificationsAsReadCommand` and `MarkNotificationsAsReadCommandHandler` to mark notifications as read.
- Added `MarkNotificationsAsReadCommandResponse`.
- Updated `GetAllNotificationsQuery` to return `GetAllNotificationsWithUnreadCountResponse`.
- Updated `GetAllNotificationsQueryHandler` to include unread count in the response.
- Fixed typo in `GetAllNotificationsQueryResponse` (`IsRread` to `IsRead`).
- Updated `INoSqlRepository` and its implementation to include a `predicate` parameter in `GetAllAsync`.
- Added `MarkNotificationsAsReadRequest`.
- Updated `NotificationsController` to include a new endpoint for marking notifications as read.
- Added `MarkNotificationsAsReadAsync` in `INotificationService` and its implementation.
- Updated `NotificationService` to use the new `GetAllAsync` method with a `predicate` parameter.